### PR TITLE
Add channel type classification during soundcheck

### DIFF
--- a/Auralis.jucer
+++ b/Auralis.jucer
@@ -32,21 +32,21 @@
         <CONFIGURATION isDebug="0" name="Release" targetName="Auralis"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
-        <MODULEPATH id="juce_analytics" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_audio_basics" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_audio_devices" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_audio_formats" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_audio_processors" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_audio_utils" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_core" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_cryptography" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_data_structures" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_dsp" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_events" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_graphics" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_gui_basics" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_gui_extra" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_osc" path="../../JUCE/modules"/>
+        <MODULEPATH id="juce_analytics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_basics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_utils" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_core" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_cryptography" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_data_structures" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_dsp" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_events" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_graphics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_basics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_extra" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_osc" path="../JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
   </EXPORTFORMATS>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,10 @@ cmake_minimum_required(VERSION 3.15)
 project(Auralis VERSION 0.1.0)
 
 # Find the JUCE library - adjust the path if needed
-set(JUCE_PATH "../../JUCE" CACHE PATH "Path to JUCE library")
+set(JUCE_PATH "../JUCE" CACHE PATH "Path to JUCE library")
+if(NOT EXISTS ${JUCE_PATH})
+    message(FATAL_ERROR "JUCE not found at ${JUCE_PATH}. Set JUCE_PATH to your local JUCE directory.")
+endif()
 add_subdirectory(${JUCE_PATH} JUCE EXCLUDE_FROM_ALL)
 
 # Basic application setup

--- a/Source/Soundcheck/SoundcheckEngine.h
+++ b/Source/Soundcheck/SoundcheckEngine.h
@@ -47,6 +47,10 @@ public:
         float originalGateThreshold = -50.0f;
         float originalEqGains[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
         float originalCompressorRatio = 1.0f;
+        ChannelProcessor::ChannelType originalType = ChannelProcessor::ChannelType::Other;
+
+        // Suggested channel type based on analysis
+        ChannelProcessor::ChannelType suggestedType = ChannelProcessor::ChannelType::Other;
     };
     
     // Public API
@@ -113,6 +117,7 @@ private:
     void calculateCorrections(int channelIndex);
     void backupOriginalSettings(int channelIndex);
     void mapFFTToThirdOctaveBands(const float* fftData, juce::Array<float>& bandMagnitudes);
+    ChannelProcessor::ChannelType classifyChannel(const juce::Array<float>& magnitudes) const;
 };
 
 // Callback class to capture audio for analysis

--- a/readme.md
+++ b/readme.md
@@ -26,3 +26,7 @@ Auralis is a modern mixing assistant that makes live worship services sound prof
 
 ## Getting Started
 See `DEV_PLAN.md` for detailed architecture and setup.
+
+The build assumes JUCE is located in `../JUCE` relative to this repository. If
+your JUCE copy lives elsewhere, pass `-DJUCE_PATH=/path/to/JUCE` to CMake when
+configuring the project.


### PR DESCRIPTION
## Summary
- classify each channel as vocal, instrument, drums or other
- store original and suggested types in analysis results
- apply detected type along with gain and DSP corrections
- revert restores original channel type

## Testing
- `cmake -B build -GNinja` *(fails: JUCE not found)*