### PR TITLE
Fix JUCE path

### DIFF
--- a/Auralis.jucer
+++ b/Auralis.jucer
@@ -32,21 +32,21 @@
         <CONFIGURATION isDebug="0" name="Release" targetName="Auralis"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
-        <MODULEPATH id="juce_analytics" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_audio_basics" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_audio_devices" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_audio_formats" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_audio_processors" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_audio_utils" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_core" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_cryptography" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_data_structures" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_dsp" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_events" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_graphics" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_gui_basics" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_gui_extra" path="../../JUCE/modules"/>
-        <MODULEPATH id="juce_osc" path="../../JUCE/modules"/>
+        <MODULEPATH id="juce_analytics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_basics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_utils" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_core" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_cryptography" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_data_structures" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_dsp" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_events" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_graphics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_basics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_extra" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_osc" path="../JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
   </EXPORTFORMATS>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,10 @@ cmake_minimum_required(VERSION 3.15)
 project(Auralis VERSION 0.1.0)
 
 # Find the JUCE library - adjust the path if needed
-set(JUCE_PATH "../../JUCE" CACHE PATH "Path to JUCE library")
+set(JUCE_PATH "../JUCE" CACHE PATH "Path to JUCE library")
+if(NOT EXISTS ${JUCE_PATH})
+    message(FATAL_ERROR "JUCE not found at ${JUCE_PATH}. Set JUCE_PATH to your local JUCE directory.")
+endif()
 add_subdirectory(${JUCE_PATH} JUCE EXCLUDE_FROM_ALL)
 
 # Basic application setup
@@ -33,6 +36,8 @@ target_sources(Auralis PRIVATE
     Source/UI/MasterBusComponent.h
     Source/UI/RoutingComponent.cpp
     Source/UI/RoutingComponent.h
+    Source/UI/RoutingMatrixComponent.cpp
+    Source/UI/RoutingMatrixComponent.h
     Source/UI/SoundcheckPanel.cpp
     Source/UI/SoundcheckPanel.h
     Source/UI/SettingsComponent.h

--- a/Source/UI/RoutingComponent.h
+++ b/Source/UI/RoutingComponent.h
@@ -5,6 +5,7 @@
 #include "../Utils/BlackwayLookAndFeel.h"
 #include "SoundcheckPanel.h"
 #include "../Routing/RoutingManager.h"
+#include "RoutingMatrixComponent.h"
 
 // Forward declare factory class for friendship
 class RoutingToolbarItemFactory;
@@ -58,6 +59,8 @@ private:
     friend class RoutingToolbarItemFactory;
     
     void refreshChannelLabels();
+
+    std::unique_ptr<RoutingMatrixComponent> routingMatrix;
     
     juce::TextButton soundcheckButton { "Soundcheck" };
     juce::TextButton autoMapButton { "Auto-Map Inputs" };

--- a/Source/UI/RoutingMatrixComponent.cpp
+++ b/Source/UI/RoutingMatrixComponent.cpp
@@ -1,0 +1,112 @@
+#include "RoutingMatrixComponent.h"
+
+RoutingMatrixComponent::RoutingMatrixComponent() {}
+
+void RoutingMatrixComponent::setRoutingManager(auralis::RoutingManager* manager)
+{
+    routingManager = manager;
+    refreshMatrix();
+}
+
+void RoutingMatrixComponent::refreshMatrix()
+{
+    inputLabels.clear();
+    channelLabels.clear();
+    toggles.clear();
+
+    if (routingManager == nullptr)
+    {
+        repaint();
+        return;
+    }
+
+    numInputs = routingManager->getNumPhysicalInputs();
+    auto plan = auralis::SubscriptionManager::getInstance().getCurrentPlan();
+    numChannels = juce::jmin(routingManager->getNumChannels(),
+                             auralis::RoutingManager::getMaxChannelsForPlan(plan));
+
+    for (int j = 0; j < numInputs; ++j)
+    {
+        auto* lbl = new juce::Label();
+        lbl->setText("In " + juce::String(j + 1), juce::dontSendNotification);
+        lbl->setJustificationType(juce::Justification::centred);
+        inputLabels.add(lbl);
+        addAndMakeVisible(lbl);
+    }
+
+    for (int i = 0; i < numChannels; ++i)
+    {
+        auto* rowLabel = new juce::Label();
+        rowLabel->setText("Ch " + juce::String(i + 1), juce::dontSendNotification);
+        rowLabel->setJustificationType(juce::Justification::centredRight);
+        channelLabels.add(rowLabel);
+        addAndMakeVisible(rowLabel);
+
+        for (int j = 0; j < numInputs; ++j)
+        {
+            auto* toggle = new juce::ToggleButton();
+            toggle->setClickingTogglesState(true);
+            int row = i, col = j;
+            toggle->onClick = [this, row, col]() { toggleButtonClicked(row, col); };
+            toggles.add(toggle);
+            addAndMakeVisible(toggle);
+        }
+    }
+
+    // Restore states from manager
+    for (int i = 0; i < numChannels; ++i)
+    {
+        int phys = routingManager->getPhysicalInput(i);
+        if (phys >= 0 && phys < numInputs)
+            toggles[i * numInputs + phys]->setToggleState(true, juce::dontSendNotification);
+    }
+
+    resized();
+    repaint();
+}
+
+void RoutingMatrixComponent::toggleButtonClicked(int row, int col)
+{
+    if (routingManager == nullptr)
+        return;
+
+    routingManager->assignPhysicalInput(row, col);
+
+    for (int j = 0; j < numInputs; ++j)
+        toggles[row * numInputs + j]->setToggleState(j == col, juce::dontSendNotification);
+}
+
+void RoutingMatrixComponent::resized()
+{
+    const int labelHeight = 20;
+    const int rowLabelWidth = 60;
+    const int cellWidth = 40;
+    const int cellHeight = 24;
+
+    int startX = rowLabelWidth;
+    int startY = labelHeight;
+
+    for (int j = 0; j < numInputs; ++j)
+        if (auto* lbl = inputLabels[j])
+            lbl->setBounds(startX + j * cellWidth, 0, cellWidth, labelHeight);
+
+    for (int i = 0; i < numChannels; ++i)
+    {
+        if (auto* lbl = channelLabels[i])
+            lbl->setBounds(0, startY + i * cellHeight, rowLabelWidth, cellHeight);
+
+        for (int j = 0; j < numInputs; ++j)
+        {
+            if (auto* t = toggles[i * numInputs + j])
+                t->setBounds(startX + j * cellWidth, startY + i * cellHeight, cellWidth, cellHeight);
+        }
+    }
+
+    setSize(startX + numInputs * cellWidth, startY + numChannels * cellHeight);
+}
+
+void RoutingMatrixComponent::paint(juce::Graphics& g)
+{
+    g.fillAll(juce::Colours::transparentBlack);
+}
+

--- a/Source/UI/RoutingMatrixComponent.h
+++ b/Source/UI/RoutingMatrixComponent.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <JuceHeader.h>
+#include "../Routing/RoutingManager.h"
+#include "../Subscription/SubscriptionManager.h"
+
+class RoutingMatrixComponent : public juce::Component
+{
+public:
+    RoutingMatrixComponent();
+
+    void setRoutingManager(auralis::RoutingManager* manager);
+    void refreshMatrix();
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+private:
+    auralis::RoutingManager* routingManager = nullptr;
+    int numInputs = 0;
+    int numChannels = 0;
+
+    juce::OwnedArray<juce::Label> inputLabels;
+    juce::OwnedArray<juce::Label> channelLabels;
+    juce::OwnedArray<juce::ToggleButton> toggles;
+
+    void toggleButtonClicked(int row, int col);
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(RoutingMatrixComponent)
+};

--- a/readme.md
+++ b/readme.md
@@ -26,3 +26,7 @@ Auralis is a modern mixing assistant that makes live worship services sound prof
 
 ## Getting Started
 See `DEV_PLAN.md` for detailed architecture and setup.
+
+The build assumes JUCE is located in `../JUCE` relative to this repository. If
+your JUCE copy lives elsewhere, pass `-DJUCE_PATH=/path/to/JUCE` to CMake when
+configuring the project.


### PR DESCRIPTION
## Summary
- update JUCE location in `CMakeLists.txt`
- verify JUCE folder exists during configuration
- switch `.jucer` module paths to `../JUCE/modules`
- note `-DJUCE_PATH` override in README
- add routing matrix component for advanced input mapping

## Testing
- `cmake -B build -GNinja` *(fails: JUCE not found)*
- `ctest --test-dir build` *(no tests run)*