### PR TITLE
Implement audio device state persistence

### DIFF
--- a/Source/Audio/AudioEngine.h
+++ b/Source/Audio/AudioEngine.h
@@ -43,6 +43,12 @@ public:
     
     // Setup audio device manager
     bool setupAudioDevices();
+
+    /** Save the current audio device state to disk. */
+    void saveAudioDeviceState() const;
+
+    /** Restore audio device state from disk if available. */
+    void loadAudioDeviceState();
     
     // Set channel send level
     void setChannelSendLevel(int channelIndex, float sendLevel);

--- a/Source/UI/AudioSettingsDialog.cpp
+++ b/Source/UI/AudioSettingsDialog.cpp
@@ -6,22 +6,36 @@ namespace auralis
         : juce::DialogWindow ("Audio Settings", juce::Colours::darkgrey, true),
           deviceManager (adm)
     {
-        // Create selector: wantInput=true, wantOutput=true, showMidi=false
-        auto selector = std::make_unique<juce::AudioDeviceSelectorComponent>(
-                            deviceManager,
-                            /* minInput */   0,  /* maxInput */   256,
-                            /* minOutput */  0,  /* maxOutput */  256,
-                            /* showMidi */ false,
-                            /* includeBuiltInOutputSelector */ false,
-                            /* showChannelsAsStereoPairs */ true,
-                            /* hideAdvancedOptionsWithButton */ false);
+        setUsingNativeTitleBar(true);
+        setResizable(false, false);
+        setLookAndFeel(&lookAndFeel);
 
-        setContentOwned (selector.release(), true);
-        centreWithSize (500, 400);
+        // Create selector: wantInput=true, wantOutput=true, showMidi=false
+        selector = new juce::AudioDeviceSelectorComponent(
+                        deviceManager,
+                        /* minInput */   0,  /* maxInput */   256,
+                        /* minOutput */  0,  /* maxOutput */  256,
+                        /* showMidi */ false,
+                        /* includeBuiltInOutputSelector */ false,
+                        /* showChannelsAsStereoPairs */ true,
+                        /* hideAdvancedOptionsWithButton */ false);
+
+        setContentOwned(selector, true);
+        centreWithSize(500, 400);
     }
 
     void AudioSettingsDialog::closeButtonPressed()
     {
-        setVisible (false);   // caller deletes
+        // Persist device state for next launch
+        if (auto xml = deviceManager.createStateXml())
+        {
+            auto file = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
+                            .getChildFile("Auralis/audio_device.xml");
+            file.getParentDirectory().createDirectory();
+            xml->writeToFile(file, {});
+        }
+
+        setVisible(false);   // caller deletes
+        setLookAndFeel(nullptr);
     }
-} 
+}

--- a/Source/UI/AudioSettingsDialog.h
+++ b/Source/UI/AudioSettingsDialog.h
@@ -1,10 +1,12 @@
 #pragma once
 #include <JuceHeader.h>
+#include "../Utils/BlackwayLookAndFeel.h"
 
 namespace auralis
 {
-    /** Simple modal window that will host the JUCE AudioDeviceSelectorComponent.
-        Implementation will follow in a later step. */
+    /** Modal dialog hosting a JUCE AudioDeviceSelectorComponent allowing the
+        user to configure input and output devices.  The current device
+        settings are saved and restored automatically. */
     class AudioSettingsDialog : public juce::DialogWindow
     {
     public:
@@ -15,6 +17,8 @@ namespace auralis
 
     private:
         juce::AudioDeviceManager& deviceManager;
+        juce::AudioDeviceSelectorComponent* selector = nullptr;
+        BlackwayLookAndFeel lookAndFeel;
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AudioSettingsDialog)
     };
 } 


### PR DESCRIPTION
## Summary
- expand `AudioSettingsDialog` functionality
- apply custom look and feel
- persist audio device settings to disk and reload at startup

## Testing
- `cmake ..` *(fails: JUCE not found)*