### PR TITLE
Introduce global style manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ target_sources(Auralis PRIVATE
     Source/State/SessionManager.h
     Source/State/SessionManager.cpp
     Source/Utils/BlackwayLookAndFeel.h
+    Source/Utils/StyleManager.cpp
+    Source/Utils/StyleManager.h
     Source/FX/TrimProcessor.cpp
     Source/FX/TrimProcessor.h
     Source/FX/GateProcessor.cpp

--- a/Source/MainApp.cpp
+++ b/Source/MainApp.cpp
@@ -2,6 +2,7 @@
 #include "UI/MainComponent.h"
 #include "MainWindow.h"
 #include "Tests/SessionRoundTripTest.h"
+#include "Utils/StyleManager.h"
 
 namespace {
     void logToStderr(const juce::String& message)
@@ -63,7 +64,10 @@ namespace {
 void MainApp::initialise(const juce::String& commandLine)
 {
     logToStderr("Creating main window");
-    
+
+    // Apply global look and feel so all components share the same style
+    StyleManager::getInstance().applyGlobalLookAndFeel();
+
     // Register commands
     commandManager.registerAllCommandsForTarget(this);
     

--- a/Source/UI/ChannelStripComponent.cpp
+++ b/Source/UI/ChannelStripComponent.cpp
@@ -2,12 +2,13 @@
 #include "LevelMeter.h"
 #include "ChannelsComponent.h"
 #include "../Audio/AudioEngine.h"
+#include "../Utils/StyleManager.h"
 
 ChannelStripComponent::ChannelStripComponent(int index, ChannelsComponent* parent)
     : parentComponent(parent), channelIndex(index)
 {
-    // Apply custom look and feel
-    setLookAndFeel(&blackwayLookAndFeel);
+    // Use the global look and feel
+    setLookAndFeel(&StyleManager::getInstance().getLookAndFeel());
     
     // Load background image
     auto assetsDir = juce::File::getCurrentWorkingDirectory().getChildFile("Assets");
@@ -34,14 +35,14 @@ ChannelStripComponent::ChannelStripComponent(int index, ChannelsComponent* paren
     // Channel index label setup
     indexLabel.setText("--", juce::dontSendNotification);
     indexLabel.setJustificationType(juce::Justification::centredLeft);
-    indexLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(14.0f).boldened());
+    indexLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(14.0f).boldened());
     indexLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     addAndMakeVisible(indexLabel);
     
     // Name Label setup
     nameLabel.setText(channelName, juce::dontSendNotification);
     nameLabel.setJustificationType(juce::Justification::centredLeft);
-    nameLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(12.0f).boldened());
+    nameLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(12.0f).boldened());
     nameLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     addAndMakeVisible(nameLabel);
     
@@ -55,13 +56,13 @@ ChannelStripComponent::ChannelStripComponent(int index, ChannelsComponent* paren
     
     trimLabel.setText("Trim", juce::dontSendNotification);
     trimLabel.setJustificationType(juce::Justification::centred);
-    trimLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(10.0f));
+    trimLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(10.0f));
     trimLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     addAndMakeVisible(trimLabel);
     
     trimValueLabel.setText("0 dB", juce::dontSendNotification);
     trimValueLabel.setJustificationType(juce::Justification::centred);
-    trimValueLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(10.0f));
+    trimValueLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(10.0f));
     trimValueLabel.setColour(juce::Label::textColourId, juce::Colours::lightgrey);
     addAndMakeVisible(trimValueLabel);
     
@@ -72,7 +73,7 @@ ChannelStripComponent::ChannelStripComponent(int index, ChannelsComponent* paren
     
     gateLabel.setText("Gate", juce::dontSendNotification);
     gateLabel.setJustificationType(juce::Justification::centred);
-    gateLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(10.0f));
+    gateLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(10.0f));
     gateLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     addAndMakeVisible(gateLabel);
     
@@ -83,7 +84,7 @@ ChannelStripComponent::ChannelStripComponent(int index, ChannelsComponent* paren
     
     compLabel.setText("Comp", juce::dontSendNotification);
     compLabel.setJustificationType(juce::Justification::centred);
-    compLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(10.0f));
+    compLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(10.0f));
     compLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     addAndMakeVisible(compLabel);
     
@@ -102,13 +103,13 @@ ChannelStripComponent::ChannelStripComponent(int index, ChannelsComponent* paren
     
     fxSendLabel.setText("FX Send", juce::dontSendNotification);
     fxSendLabel.setJustificationType(juce::Justification::centred);
-    fxSendLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(10.0f));
+    fxSendLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(10.0f));
     fxSendLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     addAndMakeVisible(fxSendLabel);
     
     fxSendValueLabel.setText("0 %", juce::dontSendNotification);
     fxSendValueLabel.setJustificationType(juce::Justification::centred);
-    fxSendValueLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(10.0f));
+    fxSendValueLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(10.0f));
     fxSendValueLabel.setColour(juce::Label::textColourId, juce::Colours::lightgrey);
     addAndMakeVisible(fxSendValueLabel);
     
@@ -120,7 +121,7 @@ ChannelStripComponent::ChannelStripComponent(int index, ChannelsComponent* paren
     
     tunerLabel.setText("Tuner", juce::dontSendNotification);
     tunerLabel.setJustificationType(juce::Justification::centred);
-    tunerLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(10.0f));
+    tunerLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(10.0f));
     tunerLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     tunerLabel.setVisible(false); // Initially hidden
     addAndMakeVisible(tunerLabel);
@@ -136,7 +137,7 @@ ChannelStripComponent::ChannelStripComponent(int index, ChannelsComponent* paren
     
     tunerValueLabel.setText("50 %", juce::dontSendNotification);
     tunerValueLabel.setJustificationType(juce::Justification::centred);
-    tunerValueLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(10.0f));
+    tunerValueLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(10.0f));
     tunerValueLabel.setColour(juce::Label::textColourId, juce::Colours::lightgrey);
     tunerValueLabel.setVisible(false); // Initially hidden
     addAndMakeVisible(tunerValueLabel);

--- a/Source/UI/ChannelStripComponent.h
+++ b/Source/UI/ChannelStripComponent.h
@@ -2,7 +2,7 @@
 
 #include <JuceHeader.h>
 #include "../Audio/ChannelProcessor.h"
-#include "../Utils/BlackwayLookAndFeel.h"
+#include "../Utils/StyleManager.h"
 
 // Forward declaration for cross-referencing
 class ChannelsComponent;
@@ -78,8 +78,7 @@ private:
     // Pointer to parent component for selection notification
     ChannelsComponent* parentComponent = nullptr;
     
-    // Custom look and feel
-    BlackwayLookAndFeel blackwayLookAndFeel;
+    // Custom look and feel is provided globally by StyleManager
     
     // UI Components
     juce::Label nameLabel;

--- a/Source/UI/ChannelsComponent.cpp
+++ b/Source/UI/ChannelsComponent.cpp
@@ -1,12 +1,14 @@
 #include "ChannelsComponent.h"
 #include "../MainApp.h"
 #include "../../Subscription/SubscriptionManager.h"
+#include "../Utils/StyleManager.h"
 
 ChannelsComponent::ChannelsComponent()
 {
-    // Apply custom look and feel
-    setLookAndFeel(&blackwayLookAndFeel);
-    horizontalScrollbar.setLookAndFeel(&blackwayLookAndFeel);
+    // Use global look and feel for consistency
+    auto& lf = StyleManager::getInstance().getLookAndFeel();
+    setLookAndFeel(&lf);
+    horizontalScrollbar.setLookAndFeel(&lf);
     
     // Load background image
     auto assetsDir = juce::File::getCurrentWorkingDirectory().getChildFile("Assets");

--- a/Source/UI/ChannelsComponent.h
+++ b/Source/UI/ChannelsComponent.h
@@ -3,7 +3,7 @@
 #include <JuceHeader.h>
 #include "ChannelStripComponent.h"
 #include "../Audio/AudioEngine.h"
-#include "../Utils/BlackwayLookAndFeel.h"
+#include "../Utils/StyleManager.h"
 
 class ChannelsComponent : public juce::Component,
                           private juce::ScrollBar::Listener
@@ -26,7 +26,6 @@ private:
     static constexpr int channelStripWidth = ChannelStripComponent::kStandardWidth;
     static constexpr int viewportMargin = ChannelStripComponent::kStandardPadding;
     
-    BlackwayLookAndFeel blackwayLookAndFeel;
     juce::Image backgroundImage;
     
     std::vector<std::unique_ptr<ChannelStripComponent>> channelStrips;

--- a/Source/UI/MainComponent.cpp
+++ b/Source/UI/MainComponent.cpp
@@ -3,14 +3,16 @@
 #include "FXBusesComponent.h"
 #include "MasterBusComponent.h"
 #include "RoutingComponent.h"
+#include "../Utils/StyleManager.h"
 
 MainComponent::MainComponent()
 {
     juce::Logger::writeToLog("MainComponent constructor start");
     
-    // Set the custom look and feel
-    setLookAndFeel(&blackwayLookAndFeel);
-    tabbedComponent.setLookAndFeel(&blackwayLookAndFeel);
+    // Use the global look and feel managed by StyleManager
+    auto& lf = StyleManager::getInstance().getLookAndFeel();
+    setLookAndFeel(&lf);
+    tabbedComponent.setLookAndFeel(&lf);
     
     // Load background image
     auto assetsDir = juce::File::getCurrentWorkingDirectory().getChildFile("Assets");

--- a/Source/UI/MainComponent.h
+++ b/Source/UI/MainComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <JuceHeader.h>
-#include "../Utils/BlackwayLookAndFeel.h"
+#include "../Utils/StyleManager.h"
 #include "../Audio/AudioEngine.h"
 #include "../Audio/MasterBusProcessor.h"
 #include "SettingsComponent.h"
@@ -19,7 +19,6 @@ public:
     void resized() override;
 
 private:
-    BlackwayLookAndFeel blackwayLookAndFeel;
     juce::Image backgroundImage;
     
     // Audio processors

--- a/Source/UI/MasterBusComponent.cpp
+++ b/Source/UI/MasterBusComponent.cpp
@@ -1,12 +1,13 @@
 #include "MasterBusComponent.h"
+#include "../Utils/StyleManager.h"
 
 MasterBusComponent::MasterBusComponent(MasterBusProcessor* processor)
     : masterProcessor(processor)
 {
     juce::Logger::writeToLog("MasterBusComponent constructor start");
     
-    // Set up the look and feel
-    setLookAndFeel(&blackwayLookAndFeel);
+    // Use global look and feel for consistency
+    setLookAndFeel(&StyleManager::getInstance().getLookAndFeel());
     
     // Load background image
     auto assetsDir = juce::File::getCurrentWorkingDirectory().getChildFile("Assets");
@@ -17,21 +18,21 @@ MasterBusComponent::MasterBusComponent(MasterBusProcessor* processor)
     
     // Output meter label
     outputMeterLabel.setText("OUTPUT", juce::dontSendNotification);
-    outputMeterLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(14.0f).boldened());
+    outputMeterLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(14.0f).boldened());
     outputMeterLabel.setJustificationType(juce::Justification::centred);
     outputMeterLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     addAndMakeVisible(outputMeterLabel);
     
     // Current LUFS display
     currentLufsLabel.setText("CURRENT: -18.0 LUFS", juce::dontSendNotification);
-    currentLufsLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(14.0f));
+    currentLufsLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(14.0f));
     currentLufsLabel.setJustificationType(juce::Justification::centredLeft);
     currentLufsLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     addAndMakeVisible(currentLufsLabel);
     
     // Target LUFS display
     targetLufsLabel.setText("TARGET: -14.0 LUFS", juce::dontSendNotification);
-    targetLufsLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(14.0f));
+    targetLufsLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(14.0f));
     targetLufsLabel.setJustificationType(juce::Justification::centredLeft);
     targetLufsLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     addAndMakeVisible(targetLufsLabel);
@@ -103,7 +104,7 @@ MasterBusComponent::MasterBusComponent(MasterBusProcessor* processor)
     
     // Set up custom LUFS label
     customLufsLabel.setText("Custom LUFS", juce::dontSendNotification);
-    customLufsLabel.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(14.0f));
+    customLufsLabel.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(14.0f));
     customLufsLabel.setJustificationType(juce::Justification::centredLeft);
     customLufsLabel.setColour(juce::Label::textColourId, juce::Colours::white);
     customLufsLabel.setVisible(false);
@@ -143,7 +144,7 @@ void MasterBusComponent::paint(juce::Graphics& g)
     
     // Draw section headers
     g.setColour(juce::Colours::white);
-    g.setFont(blackwayLookAndFeel.getRobotoFont().withHeight(16.0f).boldened());
+    g.setFont(StyleManager::getInstance().getLookAndFeel().getRobotoFont().withHeight(16.0f).boldened());
     g.drawText("MASTER BUS", 20, 10, 200, 30, juce::Justification::left);
     g.drawText("TARGET LOUDNESS", 20, 240, 200, 30, juce::Justification::left);
     g.drawText("PROCESSING", 20, 360, 200, 30, juce::Justification::left);

--- a/Source/UI/MasterBusComponent.h
+++ b/Source/UI/MasterBusComponent.h
@@ -4,7 +4,7 @@
 #include "../Audio/MasterBusProcessor.h"
 #include "LevelMeter.h"
 #include "LoudnessMeterComponent.h"
-#include "../Utils/BlackwayLookAndFeel.h"
+#include "../Utils/StyleManager.h"
 
 class MasterBusComponent : public juce::Component,
                            private juce::Timer
@@ -46,8 +46,7 @@ private:
     juce::Slider customLufsSlider;
     juce::Label customLufsLabel;
     
-    // Custom look and feel
-    BlackwayLookAndFeel blackwayLookAndFeel;
+
     
     // Loudness meter
     std::unique_ptr<auralis::LoudnessMeterComponent> meter;

--- a/Source/Utils/StyleManager.cpp
+++ b/Source/Utils/StyleManager.cpp
@@ -1,0 +1,50 @@
+#include "StyleManager.h"
+
+StyleManager& StyleManager::getInstance()
+{
+    static StyleManager instance;
+    return instance;
+}
+
+StyleManager::StyleManager()
+{
+    configureColours();
+}
+
+BlackwayLookAndFeel& StyleManager::getLookAndFeel()
+{
+    return lookAndFeel;
+}
+
+void StyleManager::applyGlobalLookAndFeel()
+{
+    juce::LookAndFeel::setDefaultLookAndFeel(&lookAndFeel);
+}
+
+void StyleManager::setTheme(Theme newTheme)
+{
+    if (currentTheme != newTheme)
+    {
+        currentTheme = newTheme;
+        configureColours();
+    }
+}
+
+StyleManager::Theme StyleManager::getTheme() const
+{
+    return currentTheme;
+}
+
+void StyleManager::configureColours()
+{
+    if (currentTheme == Theme::Dark)
+    {
+        lookAndFeel.setColour(juce::ResizableWindow::backgroundColourId, juce::Colours::black);
+        lookAndFeel.setColour(juce::Label::textColourId, juce::Colours::white);
+    }
+    else
+    {
+        lookAndFeel.setColour(juce::ResizableWindow::backgroundColourId, juce::Colours::white);
+        lookAndFeel.setColour(juce::Label::textColourId, juce::Colours::black);
+    }
+}

--- a/Source/Utils/StyleManager.h
+++ b/Source/Utils/StyleManager.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <JuceHeader.h>
+#include "BlackwayLookAndFeel.h"
+
+class StyleManager
+{
+public:
+    enum class Theme { Dark, Light };
+
+    static StyleManager& getInstance();
+
+    BlackwayLookAndFeel& getLookAndFeel();
+
+    void applyGlobalLookAndFeel();
+
+    void setTheme(Theme newTheme);
+    Theme getTheme() const;
+
+private:
+    StyleManager();
+    void configureColours();
+
+    Theme currentTheme { Theme::Dark };
+    BlackwayLookAndFeel lookAndFeel;
+};


### PR DESCRIPTION
## Summary
- add a `StyleManager` singleton to centralise UI look & feel
- apply the global look across main components
- update build files for new sources

## Testing
- `cmake -B build -S .` *(fails: JUCE not found)*