### PR TITLE
Fix missing getMaxChannelsForPlan

### DIFF
--- a/Source/Routing/RoutingManager.cpp
+++ b/Source/Routing/RoutingManager.cpp
@@ -103,4 +103,15 @@ int RoutingManager::getNumPhysicalInputs() const
     return 0;
 }
 
-} // namespace auralis 
+int RoutingManager::getMaxChannelsForPlan(auralis::Plan plan)
+{
+    switch (plan)
+    {
+        case auralis::Plan::Foundation: return 32;
+        case auralis::Plan::Flow:       return 48;
+        case auralis::Plan::Pro:        return 64;
+    }
+    return 32;
+}
+
+} // namespace auralis

--- a/Source/Routing/RoutingManager.h
+++ b/Source/Routing/RoutingManager.h
@@ -27,6 +27,13 @@ public:
     
     // Get the number of physical inputs
     int getNumPhysicalInputs() const;
+
+    /**
+     * Return the maximum number of channels allowed for the given
+     * subscription plan. This is used by UI components to limit
+     * how many channels can be shown or routed.
+     */
+    static int getMaxChannelsForPlan(auralis::Plan plan);
     
 private:
     RoutingManager() = default;


### PR DESCRIPTION
## Summary
- define `getMaxChannelsForPlan` in `RoutingManager`
- implement the method with plan limits

## Testing
- `cmake -B build` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_684792ffd16c833299a2bd48b34f712c