### PR TITLE
Fix RoutingManager include dependencies

### DIFF
--- a/Source/Routing/RoutingManager.h
+++ b/Source/Routing/RoutingManager.h
@@ -2,6 +2,7 @@
 #include <JuceHeader.h>
 #include "../Audio/ChannelProcessor.h"
 #include "../Audio/FXBusProcessor.h"
+#include "../Subscription/SubscriptionManager.h"
 
 namespace auralis {
 


### PR DESCRIPTION
## Summary
- include `SubscriptionManager` in `RoutingManager.h` so `auralis::Plan` is available

## Testing
- `cmake -S . -B build` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479559e39883329ca535068cf15ab9