### PR TITLE
Fix subscription include paths

### DIFF
--- a/Source/Routing/RoutingManager.h
+++ b/Source/Routing/RoutingManager.h
@@ -2,7 +2,7 @@
 #include <JuceHeader.h>
 #include "../Audio/ChannelProcessor.h"
 #include "../Audio/FXBusProcessor.h"
-#include "../Subscription/SubscriptionManager.h"
+#include "Subscription/SubscriptionManager.h"
 
 namespace auralis {
 

--- a/Source/UI/ChannelsComponent.cpp
+++ b/Source/UI/ChannelsComponent.cpp
@@ -1,6 +1,6 @@
 #include "ChannelsComponent.h"
 #include "../MainApp.h"
-#include "../../Subscription/SubscriptionManager.h"
+#include "Subscription/SubscriptionManager.h"
 #include "../Utils/StyleManager.h"
 
 ChannelsComponent::ChannelsComponent()

--- a/Source/UI/RoutingMatrixComponent.h
+++ b/Source/UI/RoutingMatrixComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <JuceHeader.h>
 #include "../Routing/RoutingManager.h"
-#include "../Subscription/SubscriptionManager.h"
+#include "Subscription/SubscriptionManager.h"
 
 class RoutingMatrixComponent : public juce::Component
 {


### PR DESCRIPTION
## Summary
- include SubscriptionManager via project root
- update references in RoutingManager, RoutingMatrixComponent and ChannelsComponent

## Testing
- `cmake -S . -B build` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_684798750f7c8332a7fd3c85d031907c