### PR TITLE
Remove unused ProcessSpec member

### DIFF
--- a/Source/Audio/MasterBusProcessor.cpp
+++ b/Source/Audio/MasterBusProcessor.cpp
@@ -214,7 +214,6 @@ private:
         comp.process (context);
     }
 
-    juce::dsp::ProcessSpec spec;
     static constexpr float lowCrossoverHz  = 200.0f;
     static constexpr float highCrossoverHz = 2000.0f;
     using Filter = juce::dsp::ProcessorDuplicator<juce::dsp::IIR::Filter<float>, juce::dsp::IIR::Coefficients<float>>;


### PR DESCRIPTION
## Summary
- remove a stale `ProcessSpec` member from `MultibandCompressorProcessor`

## Testing
- `cmake -S . -B build` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847af3d21f08332b27689ba48156f5d