### PR TITLE
Add default device fallback

### DIFF
--- a/Source/Audio/AudioEngine.cpp
+++ b/Source/Audio/AudioEngine.cpp
@@ -454,5 +454,11 @@ void AudioEngine::loadAudioDeviceState()
     juce::AudioDeviceManager::AudioDeviceSetup cfg;
     juce::String err = deviceManager.initialise(2, 2, xml.get(), true, {}, &cfg);
     if (err.isNotEmpty())
+    {
         juce::Logger::writeToLog("Audio init error: " + err);
+        // Fallback to defaults if the saved device is unavailable
+        err = deviceManager.initialiseWithDefaultDevices(2, 2);
+        if (err.isNotEmpty())
+            juce::Logger::writeToLog("Failed to open default devices: " + err);
+    }
 }


### PR DESCRIPTION
## Summary
- failover to default audio device if loading stored config fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853567088d08332a4f5fff38df68ea9