### PR TITLE
Fix Audio Settings dialog look and feel

### DIFF
--- a/Source/UI/AudioSettingsDialog.cpp
+++ b/Source/UI/AudioSettingsDialog.cpp
@@ -38,4 +38,10 @@ namespace auralis
         setVisible(false);   // caller deletes
         setLookAndFeel(nullptr);
     }
+
+    void AudioSettingsDialog::visibilityChanged()
+    {
+        if (isVisible())
+            setLookAndFeel(&lookAndFeel);
+    }
 }

--- a/Source/UI/AudioSettingsDialog.h
+++ b/Source/UI/AudioSettingsDialog.h
@@ -14,6 +14,7 @@ namespace auralis
         ~AudioSettingsDialog() override = default;
 
         void closeButtonPressed() override;
+        void visibilityChanged() override;
 
     private:
         juce::AudioDeviceManager& deviceManager;


### PR DESCRIPTION
## Summary
- reapply look and feel whenever the Audio Settings dialog is shown

## Testing
- `cmake -B build -S .` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535d01bfe083329c0fbf18ce26ff6c