### PR TITLE
Maintain tuner raw pointer

### DIFF
--- a/Source/Audio/ChannelProcessor.cpp
+++ b/Source/Audio/ChannelProcessor.cpp
@@ -63,9 +63,10 @@ void ChannelProcessor::createGraph()
     auto compProcessorCopy = std::make_unique<CompressorProcessor>();
     compNode = processorGraph->addNode(std::move(compProcessorCopy));
     
-    // Create and add tuner node
-    tuner = std::make_unique<auralis::TunerProcessor>();
-    tunerNode = processorGraph->addNode(std::move(tuner));
+    // Create and add tuner node. The graph will own the processor,
+    // but keep a raw pointer for parameter updates.
+    tunerNode = processorGraph->addNode(std::make_unique<auralis::TunerProcessor>());
+    tuner = static_cast<auralis::TunerProcessor*>(tunerNode->getProcessor());
     
     // Store pointers to processors so we can adjust parameters
     // The graph now owns the processor instances

--- a/Source/Audio/ChannelProcessor.h
+++ b/Source/Audio/ChannelProcessor.h
@@ -99,7 +99,7 @@ private:
     EQProcessor* eq = nullptr;
     CompressorProcessor* comp = nullptr;
     FXBusProcessor* fxSendBus = nullptr;  // Assigned by RoutingManager
-    std::unique_ptr<auralis::TunerProcessor> tuner;    // Owned by this class
+    auralis::TunerProcessor* tuner = nullptr;          // Owned by the graph
     
     // AudioProcessorGraph for connecting the processors
     std::unique_ptr<juce::AudioProcessorGraph> processorGraph;


### PR DESCRIPTION
## Summary
- keep raw pointer to `TunerProcessor` after adding the node to the audio graph
- adjust member declaration for tuner pointer

## Testing
- `cmake -B build -S .` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535e7e40e083329a4fcff390955df0