### PR TITLE
Check audio device before enumerating inputs

### DIFF
--- a/Source/Routing/RoutingManager.cpp
+++ b/Source/Routing/RoutingManager.cpp
@@ -98,8 +98,15 @@ int RoutingManager::getNumPhysicalInputs() const
     if (auto* app = dynamic_cast<MainApp*>(juce::JUCEApplication::getInstance()))
     {
         auto* device = app->getAudioEngine().getAudioDeviceManager().getCurrentAudioDevice();
-        return device != nullptr ? device->getInputChannelNames().size() : 0;
+
+        // Ensure the audio device exists and is currently active before querying it.
+        if (device != nullptr && device->isOpen())
+            return device->getInputChannelNames().size();
+
+        // Device is unavailable or changing
+        return 0;
     }
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- guard against unavailable audio device when determining number of inputs

## Testing
- `cmake ..` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853601390888332b7a017d754eabb32