### PR TITLE
Use unique_ptr for audio selector

### DIFF
--- a/Source/UI/AudioSettingsDialog.cpp
+++ b/Source/UI/AudioSettingsDialog.cpp
@@ -11,7 +11,7 @@ namespace auralis
         setLookAndFeel(&lookAndFeel);
 
         // Create selector: wantInput=true, wantOutput=true, showMidi=false
-        selector = new juce::AudioDeviceSelectorComponent(
+        selector = std::make_unique<juce::AudioDeviceSelectorComponent>(
                         deviceManager,
                         /* minInput */   0,  /* maxInput */   256,
                         /* minOutput */  0,  /* maxOutput */  256,
@@ -20,7 +20,7 @@ namespace auralis
                         /* showChannelsAsStereoPairs */ true,
                         /* hideAdvancedOptionsWithButton */ false);
 
-        setContentOwned(selector, true);
+        setContentOwned(selector.release(), true);
         centreWithSize(500, 400);
     }
 

--- a/Source/UI/AudioSettingsDialog.h
+++ b/Source/UI/AudioSettingsDialog.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <JuceHeader.h>
+#include <memory>
 #include "../Utils/BlackwayLookAndFeel.h"
 
 namespace auralis
@@ -18,7 +19,7 @@ namespace auralis
 
     private:
         juce::AudioDeviceManager& deviceManager;
-        juce::AudioDeviceSelectorComponent* selector = nullptr;
+        std::unique_ptr<juce::AudioDeviceSelectorComponent> selector;
         BlackwayLookAndFeel lookAndFeel;
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (AudioSettingsDialog)
     };


### PR DESCRIPTION
## Summary
- manage AudioDeviceSelectorComponent with `std::unique_ptr`
- transfer component ownership when creating the dialog

## Testing
- `cmake -B build` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853619ec4e88332bdb16c378956e26a